### PR TITLE
Miscellaneous fixes

### DIFF
--- a/dtbase/core/models.py
+++ b/dtbase/core/models.py
@@ -205,7 +205,12 @@ def insert_model_product(model_run, measure_name, values, timestamps, session=No
         }
         for value, timestamp in zip(values, timestamps)
     ]
-    session.execute(values_class.__table__.insert(), rows)
+    session.execute(
+        sqla.dialects.postgresql.insert(
+            values_class.__table__
+        ).on_conflict_do_nothing(),
+        rows,
+    )
     session.flush()
 
 

--- a/dtbase/core/sensors.py
+++ b/dtbase/core/sensors.py
@@ -221,7 +221,12 @@ def insert_sensor_readings(
         }
         for value, timestamp in zip(readings, timestamps)
     ]
-    session.execute(readings_class.__table__.insert(), rows)
+    session.execute(
+        sqla.dialects.postgresql.insert(
+            readings_class.__table__
+        ).on_conflict_do_nothing(),
+        rows,
+    )
     session.flush()
 
 

--- a/dtbase/core/structure.py
+++ b/dtbase/core/structure.py
@@ -56,6 +56,8 @@ class Location(BASE):
         ForeignKey("location_schema.id"),
         nullable=False,
     )
+    time_created = Column(DateTime(timezone=True), server_default=func.now())
+    time_updated = Column(DateTime(timezone=True), onupdate=func.now())
 
     # relationshionships (One-To-Many)
     string_values_relationship = relationship("LocationStringValue")
@@ -79,6 +81,9 @@ class LocationIdentifier(BASE):
     name = Column(String(100), nullable=False)
     units = Column(String(100), nullable=True)
     datatype = Column(datatype_name, nullable=False)
+    time_created = Column(DateTime(timezone=True), server_default=func.now())
+    time_updated = Column(DateTime(timezone=True), onupdate=func.now())
+
     __table_args__ = (UniqueConstraint("name", "units"),)
 
 
@@ -90,6 +95,9 @@ class LocationSchema(BASE):
     id = Column(Integer, primary_key=True, autoincrement=True)
     name = Column(String(100), nullable=False)
     description = Column(Text, nullable=True)
+    time_created = Column(DateTime(timezone=True), server_default=func.now())
+    time_updated = Column(DateTime(timezone=True), onupdate=func.now())
+
     __table_args__ = (UniqueConstraint("name"),)
 
 
@@ -115,6 +123,9 @@ class LocationSchemaIdentifierRelation(BASE):
         ForeignKey("location_identifier.id"),
         nullable=False,
     )
+    time_created = Column(DateTime(timezone=True), server_default=func.now())
+    time_updated = Column(DateTime(timezone=True), onupdate=func.now())
+
     __table_args__ = (UniqueConstraint("schema_id", "identifier_id"),)
 
 
@@ -139,6 +150,9 @@ class LocationStringValue(BASE):
         ForeignKey("location.id", ondelete="CASCADE", onupdate="CASCADE"),
         nullable=False,
     )
+    time_created = Column(DateTime(timezone=True), server_default=func.now())
+    time_updated = Column(DateTime(timezone=True), onupdate=func.now())
+
     __table_args__ = (UniqueConstraint("identifier_id", "location_id"),)
 
 
@@ -163,6 +177,9 @@ class LocationIntegerValue(BASE):
         ForeignKey("location.id", ondelete="CASCADE", onupdate="CASCADE"),
         nullable=False,
     )
+    time_created = Column(DateTime(timezone=True), server_default=func.now())
+    time_updated = Column(DateTime(timezone=True), onupdate=func.now())
+
     __table_args__ = (UniqueConstraint("identifier_id", "location_id"),)
 
 
@@ -187,6 +204,9 @@ class LocationFloatValue(BASE):
         ForeignKey("location.id", ondelete="CASCADE", onupdate="CASCADE"),
         nullable=False,
     )
+    time_created = Column(DateTime(timezone=True), server_default=func.now())
+    time_updated = Column(DateTime(timezone=True), onupdate=func.now())
+
     __table_args__ = (UniqueConstraint("identifier_id", "location_id"),)
 
 
@@ -211,6 +231,9 @@ class LocationBooleanValue(BASE):
         ForeignKey("location.id", ondelete="CASCADE", onupdate="CASCADE"),
         nullable=False,
     )
+    time_created = Column(DateTime(timezone=True), server_default=func.now())
+    time_updated = Column(DateTime(timezone=True), onupdate=func.now())
+
     __table_args__ = (UniqueConstraint("identifier_id", "location_id"),)
 
 
@@ -231,6 +254,8 @@ class Sensor(BASE):
     unique_identifier = Column(String(100), nullable=False)
     name = Column(String(100), nullable=True)
     notes = Column(Text, nullable=True)
+    time_created = Column(DateTime(timezone=True), server_default=func.now())
+    time_updated = Column(DateTime(timezone=True), onupdate=func.now())
 
     # relationshionships (One-To-Many)
     string_values_relationship = relationship("SensorStringReading")
@@ -254,6 +279,9 @@ class SensorMeasure(BASE):
     name = Column(String(100), nullable=False)
     units = Column(String(100), nullable=True)
     datatype = Column(datatype_name, nullable=False)
+    time_created = Column(DateTime(timezone=True), server_default=func.now())
+    time_updated = Column(DateTime(timezone=True), onupdate=func.now())
+
     __table_args__ = (UniqueConstraint("name", "units"),)
 
 
@@ -265,6 +293,9 @@ class SensorType(BASE):
     id = Column(Integer, primary_key=True, autoincrement=True)
     name = Column(String(100), nullable=False)
     description = Column(Text, nullable=True)
+    time_created = Column(DateTime(timezone=True), server_default=func.now())
+    time_updated = Column(DateTime(timezone=True), onupdate=func.now())
+
     __table_args__ = (UniqueConstraint("name"),)
 
 
@@ -286,6 +317,9 @@ class SensorTypeMeasureRelation(BASE):
         ForeignKey("sensor_measure.id"),
         nullable=False,
     )
+    time_created = Column(DateTime(timezone=True), server_default=func.now())
+    time_updated = Column(DateTime(timezone=True), onupdate=func.now())
+
     __table_args__ = (UniqueConstraint("type_id", "measure_id"),)
 
 
@@ -310,6 +344,9 @@ class SensorStringReading(BASE):
         nullable=False,
     )
     timestamp = Column(DateTime(timezone=True), nullable=False)
+    time_created = Column(DateTime(timezone=True), server_default=func.now())
+    time_updated = Column(DateTime(timezone=True), onupdate=func.now())
+
     __table_args__ = (UniqueConstraint("measure_id", "sensor_id", "timestamp"),)
 
 
@@ -334,6 +371,9 @@ class SensorIntegerReading(BASE):
         nullable=False,
     )
     timestamp = Column(DateTime(timezone=True), nullable=False)
+    time_created = Column(DateTime(timezone=True), server_default=func.now())
+    time_updated = Column(DateTime(timezone=True), onupdate=func.now())
+
     __table_args__ = (UniqueConstraint("measure_id", "sensor_id", "timestamp"),)
 
 
@@ -358,6 +398,9 @@ class SensorFloatReading(BASE):
         nullable=False,
     )
     timestamp = Column(DateTime(timezone=True), nullable=False)
+    time_created = Column(DateTime(timezone=True), server_default=func.now())
+    time_updated = Column(DateTime(timezone=True), onupdate=func.now())
+
     __table_args__ = (UniqueConstraint("measure_id", "sensor_id", "timestamp"),)
 
 
@@ -382,6 +425,9 @@ class SensorBooleanReading(BASE):
         nullable=False,
     )
     timestamp = Column(DateTime(timezone=True), nullable=False)
+    time_created = Column(DateTime(timezone=True), server_default=func.now())
+    time_updated = Column(DateTime(timezone=True), onupdate=func.now())
+
     __table_args__ = (UniqueConstraint("measure_id", "sensor_id", "timestamp"),)
 
 
@@ -403,6 +449,7 @@ class SensorLocation(BASE):
     location_id = Column(Integer, ForeignKey("location.id"), nullable=False)
     installation_datetime = Column(DateTime(timezone=True), nullable=False)
     time_created = Column(DateTime(timezone=True), server_default=func.now())
+    time_updated = Column(DateTime(timezone=True), onupdate=func.now())
 
     # arguments
     __table_args__ = (UniqueConstraint("sensor_id", "installation_datetime"),)
@@ -422,6 +469,8 @@ class Model(BASE):
     # columns
     id = Column(Integer, primary_key=True)
     name = Column(String(100), nullable=False, unique=True)
+    time_created = Column(DateTime(timezone=True), server_default=func.now())
+    time_updated = Column(DateTime(timezone=True), onupdate=func.now())
 
 
 class ModelScenario(BASE):
@@ -445,6 +494,8 @@ class ModelScenario(BASE):
         nullable=False,
     )
     description = Column(Text, nullable=True)
+    time_created = Column(DateTime(timezone=True), server_default=func.now())
+    time_updated = Column(DateTime(timezone=True), onupdate=func.now())
 
     # arguments
     __table_args__ = (UniqueConstraint("model_id", "description"),)
@@ -465,6 +516,9 @@ class ModelMeasure(BASE):
     name = Column(String(100))
     units = Column(String(100), nullable=False)
     datatype = Column(datatype_name, nullable=False)
+    time_created = Column(DateTime(timezone=True), server_default=func.now())
+    time_updated = Column(DateTime(timezone=True), onupdate=func.now())
+
     # arguments
     __table_args__ = (UniqueConstraint("name", "units"),)
 
@@ -482,6 +536,7 @@ class ModelRun(BASE):
     model_id = Column(Integer, ForeignKey("model.id"), nullable=False)
     scenario_id = Column(Integer, ForeignKey("model_scenario.id"), nullable=True)
     time_created = Column(DateTime(timezone=True), server_default=func.now())
+    time_updated = Column(DateTime(timezone=True), onupdate=func.now())
 
     # arguments
     __table_args__ = (UniqueConstraint("model_id", "scenario_id", "time_created"),)
@@ -503,6 +558,8 @@ class ModelProduct(BASE):
         nullable=False,
     )
     measure_id = Column(Integer, ForeignKey("model_measure.id"), nullable=False)
+    time_created = Column(DateTime(timezone=True), server_default=func.now())
+    time_updated = Column(DateTime(timezone=True), onupdate=func.now())
 
     # arguments
     __table_args__ = (UniqueConstraint("run_id", "measure_id"),)
@@ -524,6 +581,9 @@ class ModelStringValue(BASE):
     )
     timestamp = Column(DateTime(timezone=True), nullable=False)
     value = Column(String, nullable=False)
+    time_created = Column(DateTime(timezone=True), server_default=func.now())
+    time_updated = Column(DateTime(timezone=True), onupdate=func.now())
+
     # arguments
     __table_args__ = (UniqueConstraint("product_id", "timestamp"),)
 
@@ -544,6 +604,9 @@ class ModelIntegerValue(BASE):
     )
     timestamp = Column(DateTime(timezone=True), nullable=False)
     value = Column(Integer, nullable=False)
+    time_created = Column(DateTime(timezone=True), server_default=func.now())
+    time_updated = Column(DateTime(timezone=True), onupdate=func.now())
+
     # arguments
     __table_args__ = (UniqueConstraint("product_id", "timestamp"),)
 
@@ -560,6 +623,9 @@ class ModelFloatValue(BASE):
     product_id = Column(Integer, ForeignKey("model_product.id"), nullable=False)
     timestamp = Column(DateTime(timezone=True), nullable=False)
     value = Column(Float, nullable=False)
+    time_created = Column(DateTime(timezone=True), server_default=func.now())
+    time_updated = Column(DateTime(timezone=True), onupdate=func.now())
+
     # arguments
     __table_args__ = (UniqueConstraint("product_id", "timestamp"),)
 
@@ -580,6 +646,9 @@ class ModelBooleanValue(BASE):
     )
     timestamp = Column(DateTime(timezone=True), nullable=False)
     value = Column(Boolean, nullable=False)
+    time_created = Column(DateTime(timezone=True), server_default=func.now())
+    time_updated = Column(DateTime(timezone=True), onupdate=func.now())
+
     # arguments
     __table_args__ = (UniqueConstraint("product_id", "timestamp"),)
 
@@ -599,7 +668,6 @@ class User(BASE, UserMixin):
     username = Column(String, nullable=False, unique=True)
     email = Column(String, nullable=False, unique=True)
     password = Column(LargeBinary, nullable=False)
-
     time_created = Column(DateTime(timezone=True), server_default=func.now())
     time_updated = Column(DateTime(timezone=True), onupdate=func.now())
 

--- a/dtbase/tests/test_sensors.py
+++ b/dtbase/tests/test_sensors.py
@@ -282,20 +282,26 @@ def test_insert_sensor_readings_wrong_type(session):
 
 
 def test_insert_sensor_readings_duplicate(session):
-    """Try to insert sensor readings that conflict with existing ones."""
+    """Test that we can insert sensor readings that include some that have already been
+    inserted.
+    """
     insert_readings(session)
-    error_msg = (
-        "duplicate key value violates unique constraint "
-        '"sensor_float_reading_measure_id_sensor_id_timestamp_key"'
+    new_time = dt.datetime.fromisoformat("2022-10-13T01:00:00+00:00")
+    sensors.insert_sensor_readings(
+        "temperature",
+        SENSOR_ID1,
+        TEMPERATURES + [23.0],
+        TIMESTAMPS + [new_time],
+        session=session,
     )
-    with pytest.raises(sqla.exc.IntegrityError, match=error_msg):
-        sensors.insert_sensor_readings(
-            "temperature",
-            SENSOR_ID1,
-            [23.0, 23.0, 23.0],
-            TIMESTAMPS,
-            session=session,
-        )
+    read_readings = sensors.get_sensor_readings(
+        "temperature",
+        SENSOR_ID1,
+        dt_from=TIMESTAMPS[0],
+        dt_to=new_time,
+        session=session,
+    )
+    assert len(read_readings) == len(TIMESTAMPS) + 1
 
 
 def test_list_sensors(session):


### PR DESCRIPTION
Two things that came up when implementing the Hyper ingress function:
1) Fix `insert_readings` so that it's fine if we try to reinsert some readings that are already there.
2) Add `time_created` and `time_updated ` columns to all tables. Not really necessary, but would have been handy, and I think we discussed this at some point.