### PR TITLE
Fix weather ingress

### DIFF
--- a/dtbase/backend/api/sensor/routes.py
+++ b/dtbase/backend/api/sensor/routes.py
@@ -37,7 +37,6 @@ def insert_sensor_type():
     if error_response:
         return error_response
 
-    idnames = []
     db.session.begin()
     for measure in payload["measures"]:
         try:
@@ -47,14 +46,13 @@ def insert_sensor_type():
                 datatype=measure["datatype"],
                 session=db.session,
             )
-            idnames.append(measure["name"])
         except sqla.exc.IntegrityError:
             db.session.rollback()
     try:
         sensors.insert_sensor_type(
             name=payload["name"],
             description=payload["description"],
-            measures=idnames,
+            measures=payload["measures"],
             session=db.session,
         )
     except sqla.exc.IntegrityError:

--- a/dtbase/core/sensors.py
+++ b/dtbase/core/sensors.py
@@ -13,22 +13,31 @@ from dtbase.core import utils
 
 
 @add_default_session
-def measure_id_from_name(measure_name, session=None):
-    """Find the id of a sensor measure of the given name.
+def measure_id_from_name_and_units(measure_name, measure_units, session=None):
+    """
+    Find the id of a sensor measure of the given name and units.
+    (Note that our uniqueness constraint is on the name+units combination)
 
     Args:
         measure_name: Name of the sensor measure
+        measure_units: Name of the sensor measure
         session: SQLAlchemy session. Optional.
 
     Returns:
         Database id of the sensor measure.
     """
-    query = sqla.select(SensorMeasure.id).where(SensorMeasure.name == measure_name)
+    query = sqla.select(SensorMeasure.id).where(
+        (SensorMeasure.name == measure_name) & (SensorMeasure.units == measure_units)
+    )
     result = session.execute(query).fetchall()
     if len(result) == 0:
-        raise ValueError(f"No sensor measure named '{measure_name}'")
+        raise ValueError(
+            f"No sensor measure named '{measure_name}' with units '{measure_units}'"
+        )
     if len(result) > 1:
-        raise ValueError(f"Multiple sensor measures named '{measure_name}'")
+        raise ValueError(
+            f"Multiple sensor measures named '{measure_name}' with units '{measure_units}'"
+        )
     return result[0][0]
 
 
@@ -108,8 +117,8 @@ def insert_sensor_type(name, description, measures, session=None):
         name: Name of this sensor type
         description: Free form text description, for human consumption.
         measures: List of sensor measures that this sensor type can report.
-            This should be a list of strings, that are the names of existing measures
-            in the database.
+            This should be a list of dicts with keys 'name' and 'units', that
+            correspond to existing measures in the database.
         session: SQLAlchemy session. Optional.
 
     Returns:
@@ -118,8 +127,10 @@ def insert_sensor_type(name, description, measures, session=None):
     new_type = SensorType(name=name, description=description)
     session.add(new_type)
     session.flush()
-    for measure_name in measures:
-        measure_id = measure_id_from_name(measure_name, session=session)
+    for measure in measures:
+        measure_id = measure_id_from_name_and_units(
+            measure["name"], measure["units"], session=session
+        )
         session.add(
             SensorTypeMeasureRelation(type_id=new_type.id, measure_id=measure_id)
         )
@@ -165,6 +176,9 @@ def insert_sensor_readings(
 
     Returns:
         None
+
+    Note that there can be two sensor measures with the same name (but
+    different units), so we look at the sensor_type to disambiguate.
     """
     if len(readings) != len(timestamps):
         raise ValueError(
@@ -212,7 +226,15 @@ def insert_sensor_readings(
     # All seems well, insert the values.
     # We use SQLAlchemy Core rather than ORM for performance reasons:
     # https://docs.sqlalchemy.org/en/14/faq/performance.html#i-m-inserting-400-000-rows-with-the-orm-and-it-s-really-slow
-    measure_id = measure_id_from_name(measure_name, session=session)
+    measures_for_sensor = get_measures_for_sensor_identifier(
+        sensor_uniq_id, session=session
+    )
+    measure_units = next(
+        m["units"] for m in measures_for_sensor if m["name"] == measure_name
+    )
+    measure_id = measure_id_from_name_and_units(
+        measure_name, measure_units, session=session
+    )
     sensor_id = sensor_id_from_unique_identifier(sensor_uniq_id, session=session)
     rows = [
         {
@@ -230,6 +252,29 @@ def insert_sensor_readings(
         rows,
     )
     session.flush()
+
+
+@add_default_session
+def get_measures_for_sensor_identifier(sensor_unique_id, session=None):
+    """
+    Get list of sensor measures for a sensor
+
+    Args:
+        sensor_unique_id:str, id of the sensor
+        session: SQLAlchemy session. Optional.
+    Returns:
+        measure_list:list of dicts, each with keys "id","name","units","datatype"
+    """
+    all_types = list_sensor_types(session=session)
+    query = sqla.select(
+        Sensor.type_id,
+    ).where(Sensor.unique_identifier == sensor_unique_id)
+    result = session.execute(query).fetchall()
+    sensor_type = next(st for st in all_types if st["id"] == result[0][0])
+    if sensor_type:
+        return sensor_type["measures"]
+    else:
+        return []
 
 
 @add_default_session

--- a/dtbase/ingress/ingress_utils.py
+++ b/dtbase/ingress/ingress_utils.py
@@ -14,7 +14,7 @@ def backend_call(request_type, end_point_path, payload):
     request_func = getattr(requests, request_type)
     url = f"{CONST_BACKEND_URL}{end_point_path}"
     headers = {"content-type": "application/json"}
-    response = request_func(url, headers=headers, json=json.dumps(payload))
+    response = request_func(url, headers=headers, json=payload)
     return response
 
 

--- a/dtbase/tests/test_api_sensors.py
+++ b/dtbase/tests/test_api_sensors.py
@@ -57,6 +57,37 @@ def test_insert_sensor(client):
         assert response.status_code == 201
 
 
+def insert_temperature_sensor(client):
+    # insert a temperature sensor
+    type_data = {
+        "name": "simpletemp",
+        "description": "Simple temperature sensor",
+        "measures": [
+            {"name": "temperature", "units": "Kelvin", "datatype": "float"},
+        ],
+    }
+    response = client.post("/sensor/insert_sensor_type", json=type_data)
+    return response
+
+
+@pytest.mark.skipif(not DOCKER_RUNNING, reason="requires docker")
+def test_insert_two_sensor_types_sharing_measure(client):
+    with client:
+        response = insert_weather_type(client)
+        assert response.status_code == 201
+        response = insert_temperature_sensor(client)
+        assert response.status_code == 201
+        response = client.get("/sensor/list_sensor_types")
+        stypes = response.json
+        assert len(stypes) == 2
+        weather = next(t for t in stypes if t["name"] == "weather")
+        assert isinstance(weather, dict)
+        assert len(weather["measures"]) == 2
+        temp = next(t for t in stypes if t["name"] == "simpletemp")
+        assert isinstance(temp, dict)
+        assert len(temp["measures"]) == 1
+
+
 @pytest.mark.skipif(not DOCKER_RUNNING, reason="requires docker")
 def test_list_sensors_of_a_type(client):
     with client:

--- a/dtbase/tests/test_sensors.py
+++ b/dtbase/tests/test_sensors.py
@@ -47,13 +47,16 @@ def insert_types(dbsession):
     sensors.insert_sensor_type(
         name="weather",
         description="Weather sensor for temperature and rain",
-        measures=["temperature", "is raining"],
+        measures=[
+            {"name": "temperature", "units": "Kelvin", "datatype": "float"},
+            {"name": "is raining", "units": "", "datatype": "boolean"},
+        ],
         session=dbsession,
     )
     sensors.insert_sensor_type(
         name="temperature",
         description="Temperature sensor",
-        measures=["temperature"],
+        measures=[{"name": "temperature", "units": "Kelvin", "datatype": "float"}],
         session=dbsession,
     )
 
@@ -139,7 +142,7 @@ def test_insert_sensor_types_duplicate(session):
         )
 
 
-def test_insert_sensor_types_no_measurer(session):
+def test_insert_sensor_types_no_measure(session):
     """Try to insert a sensor type that uses measures that don't exist."""
     insert_types(session)
     error_msg = "No sensor measure named 'is raining misspelled'"

--- a/dtbase/tests/test_sensors.py
+++ b/dtbase/tests/test_sensors.py
@@ -150,7 +150,10 @@ def test_insert_sensor_types_no_measure(session):
         sensors.insert_sensor_type(
             name="weather misspelled",
             description="Temperature and rain misspelled",
-            measures=["temperature", "is raining misspelled"],
+            measures=[
+                {"name": "temperature", "units": "Kelvin"},
+                {"name": "is raining misspelled", "units": ""},
+            ],
             session=session,
         )
 

--- a/dtbase/tests/upload_synthetic_data.py
+++ b/dtbase/tests/upload_synthetic_data.py
@@ -32,7 +32,10 @@ def insert_trh_sensor(sensor_unique_id, session):
     insert_sensor_type(
         name="TRH",
         description="Temperature/Humidity",
-        measures=["Temperature", "Humidity"],
+        measures=[
+            {"name": "Temperature", "units": "Degrees C", "datatype": "float"},
+            {"name": "Humidity", "units": "Percent", "datatype": "float"},
+        ],
         session=session,
     )
     insert_sensor(type_name="TRH", unique_identifier=sensor_unique_id, session=session)


### PR DESCRIPTION
* Fix one remaining unnecessary json.dumps in weather ingress function.
* Revision of how we add sensor_types along with measures, based on the fact that unique constraint for sensor measures is on both name and units.   This means that we can't rely on `measure_id_from_name`, so modify this to `measure_id_from_name_and_units`, and any time we add a sensor type along with measures, we now need to give it a list of dicts containing both "name" and "units", rather than just a list of names.