### PR TITLE
add specific python version to developer docs

### DIFF
--- a/DeveloperDocs.md
+++ b/DeveloperDocs.md
@@ -1,6 +1,7 @@
 ## Running DTBase locally.
 
-* We recommend that you use a fresh Python environment (either via virtualenv, conda, or poetry), and Python version 3.8 or later.
+* We recommend that you use a fresh Python environment (either via virtualenv, conda, or poetry), and **Python version >=3.8 and <= 3.10.**
+
 * Clone this repository and change to this directory.
 * Install the `dtbase` package and dependencies by running
 ```


### PR DESCRIPTION
resolve #91 

Came across incompatible python version when setting up my environment. 

I did experiment with putting version in `requires-python` in the setup.py but it didn't make the resulting pip error any clearer so I've left it for now. 

Should probably be better addressed if/when we move from setup.py to pyproject.toml