### PR TITLE
Update pulumi config

### DIFF
--- a/infrastructure/Pulumi.test.yaml
+++ b/infrastructure/Pulumi.test.yaml
@@ -4,6 +4,10 @@ config:
   azure-native:location: UKSouth
   dtbase-azure:default-user-password:
     secure: v1:i3uapFVLBvIIP9ET:gPVpIFEY+bFtPZbt6QoDPdEVau4LoHWI
+  dtbase-azure:frontend-secret-key:
+    secure: v1:lEhsnuDLGNHWKkqU:GefIErqLt3Ee5/DkdtMmM+VD+yGCnXpqbYIMoqYRjc08s6Wk0EdwX50PaOte1dBr95b1/vLodj/CWpMBTVsHvcA2yrh4BWj0QxeoaijslCK3Yxu1
+  dtbase-azure:jwt-secret-key:
+    secure: v1:CXYpLNXsn0XNv2VX:fE9HjpJFnj4eUGoI7W65AmG36F8p8/Gu+jhxuyaapTSau6NcARKhQI2TMuAelu13Qw7XtNYsdDtin0zOmlh3n4QIWBYy6ZHfhbUp8qLZkHdGsYWwP+Se8A==
   dtbase-azure:resource-name-prefix:
     secure: v1:wIdQP6Thgn7DKKnN:/K+TreJIcI3OwffS7MmP8HpfmBFk7ViSXWE=
   dtbase-azure:sql-server-password:

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -2,7 +2,7 @@
 
 0. Install Pulumi if you haven't yet. See https://www.pulumi.com/
 1. Create an Azure storage account. This storage will only be used to hold Pulumi backend state data.
-2. Set AZURE_STORAGE_ACCOUNT and AZURE_STORAGE_KEY in .secrets/dtenv.sh. AZURE_STORAGE_ACCOUNT is the name of the storage account you created, AZURE_STORAGE_KEY can be found in the Access Keys of that account.  You also need to add the line
+2. Set `AZURE_STORAGE_ACCOUNT` and `AZURE_STORAGE_KEY` in `.secrets/dtenv.sh`. `AZURE_STORAGE_ACCOUNT` is the name of the storage account you created, `AZURE_STORAGE_KEY` can be found in the Access Keys of that account.  You also need to add the line
 `export AZURE_KEYVAULT_AUTH_VIA_CLI="true"`.
 3. Create a blob storage container within the storage account.
 4. In a terminal run `source .secrets/dtenv.sh` and then `pulumi login azblob://<NAME OF STORAGE CONTAINER>`. Note that this affects your use of pulumi system-wide, you'll have to login to a different backend to manage different projects.
@@ -13,3 +13,9 @@
 10. Make sure you're in a Python virtual environment with Pulumi SDK installed (`pip install .[infrastructure]` should cover your needs).
 11. Set all the necessary configurations with `pulumi config set` and `pulumi config set --secret`. You'll find these in `__main__.py`, or you can keep adding them until `pulumi up` stops complaining.
 12. Run `pulumi up` to stand up your new Pulumi stack.
+13. As of 2023-11-30, the creation of one resource, the PostgreSQL database, fails. This
+    seems to be an issue with Pulumi, see comments in `__main__.create_pg_database`.
+    Once all the other resources have been created with `pulumi up`, and it's only
+    complaining about the database failing, you can manually login to the PostgreSQL
+    server you've created and create the database yourself. You will then have a
+    functioning deployment of DTBase. Hopefully soon this workaround won't be necessary.

--- a/infrastructure/__main__.py
+++ b/infrastructure/__main__.py
@@ -60,8 +60,13 @@ def create_sql_server(resource_group: resource.ResourceGroup) -> postgresql.Serv
 def create_pg_database(
     resource_group: resource.ResourceGroup, sql_server: postgresql.Server
 ) -> postgresql.Database:
+    # TODO This is broken as of 2023-11-30. I'm not sure why, but I've raised an issue
+    # on pulumi: https://github.com/pulumi/pulumi-azure-native/issues/2916
+    # That this resource fails to get created doesn't interfere with anything else, so
+    # one can run `pulumi up`, get all the other stuff going, and then manually go and
+    # create a database called ${SQL_DB_NAME} on the PostgreSQL server.
     pg_database = postgresql.Database(
-        SQL_DB_NAME,
+        f"{RESOURCE_NAME_PREFIX}-postgresql-db",
         charset="UTF8",
         collation="English_United States.1252",
         database_name=SQL_DB_NAME,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,8 +61,8 @@ dev = [
     "ruff ~= 0.1.5",
 ]
 infrastructure = [
-    "pulumi ~= 3.93.0",
-    "pulumi-azure-native ~= 2.17.0",
+    "pulumi ~= 3.94",
+    "pulumi-azure-native ~= 2.20",
 ]
 
 [project.urls]


### PR DESCRIPTION
There are a few things going on here
* I added the secret keys that the frontend and backend need to the pulumi config.
* I upgraded to the latest version of pulumi. This required some changes to the config script (`__main__.py`), since there had been a major version upgrade to pulumi_azure_native since I wrote the script.
* As a consequence of the upgrade (I think it's a consequence of that) pulumi is now creating the new kinds of "flexible" postgresql servers, which are cheaper, allow us to use the latest version of postgres (16), and don't have the problem where Azure is planning to deprecate the old-style "single server" postgres servers.
* Also as a consequence of that, the part of the pulumi script that creates the `dtdb` database on that postgres server doesn't work anymore. I opened a Pulumi issue here: https://github.com/pulumi/pulumi-azure-native/issues/2916
* I added some comments for how to work around that problem.

In some sense this is a regression, since the Pulumi deployment used to just work, and now one part of it fails, and you have create the database manually. However, given that we do some serious upgrading to newer versions for pulumi, postgres, and Azure postgres servers here, I think it might still be worth to merge this.

Closes #148 and #138