### PR TITLE
parsleys and favicon added #153

### DIFF
--- a/dtbase/webapp/app/base/templates/base_site.html
+++ b/dtbase/webapp/app/base/templates/base_site.html
@@ -5,6 +5,7 @@
       {% block meta %}
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
         <!-- Meta, title, CSS, favicons, etc. -->
+        <link rel="icon" href="{{ url_for('static', filename='images/favicon.ico') }}" type="image/ico" />
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/dtbase/webapp/app/base/templates/login/login.html
+++ b/dtbase/webapp/app/base/templates/login/login.html
@@ -10,8 +10,6 @@
 {% block body_class %}login{% endblock body_class %}
 
 {% block body %}
-  <!-- Parsley -->
-  <script src="{{ url_for('static', filename='node_modules/parsleyjs/dist/parsley.min.js') }}"></script>
   <div>
     <div class="login_wrapper">
       <div class="form login_form">
@@ -37,6 +35,8 @@
   </div>
   {% block javascripts %}
   {{ super() }}
+    <!-- Parsley -->
+    <script src="{{ url_for('static', filename='node_modules/parsleyjs/dist/parsley.min.js') }}"></script>
     <!-- Utility -->
     <script src="{{url_for('static', filename='javascript/utility.js')}}"></script>
   {% endblock javascripts %}

--- a/dtbase/webapp/package-lock.json
+++ b/dtbase/webapp/package-lock.json
@@ -24,7 +24,8 @@
         "datatables.net-scroller-bs": "^2.1.1",
         "font-awesome": "^4.7.0",
         "jquery": "^3.6.4",
-        "moment": "^2.29.4"
+        "moment": "^2.29.4",
+        "parsleyjs": "^2.3.13"
       },
       "devDependencies": {
         "eslint": "^8.25.0",
@@ -1088,6 +1089,14 @@
         "node": ">=6"
       }
     },
+    "node_modules/parsleyjs": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/parsleyjs/-/parsleyjs-2.9.2.tgz",
+      "integrity": "sha512-DKS2XXTjEUZ1BJWUzgXAr+550kFBZrom2WYweubqdV7WzdNC1hjOajZDfeBPoAZMkXumJPlB3v37IKatbiW8zQ==",
+      "dependencies": {
+        "jquery": ">=1.8.0"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -1337,9 +1346,9 @@
       }
     },
     "node_modules/word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -2168,6 +2177,14 @@
         "callsites": "^3.0.0"
       }
     },
+    "parsleyjs": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/parsleyjs/-/parsleyjs-2.9.2.tgz",
+      "integrity": "sha512-DKS2XXTjEUZ1BJWUzgXAr+550kFBZrom2WYweubqdV7WzdNC1hjOajZDfeBPoAZMkXumJPlB3v37IKatbiW8zQ==",
+      "requires": {
+        "jquery": ">=1.8.0"
+      }
+    },
     "path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -2319,9 +2336,9 @@
       }
     },
     "word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true
     },
     "wrappy": {

--- a/dtbase/webapp/package.json
+++ b/dtbase/webapp/package.json
@@ -25,7 +25,8 @@
     "datatables.net-scroller-bs": "^2.1.1",
     "font-awesome": "^4.7.0",
     "jquery": "^3.6.4",
-    "moment": "^2.29.4"
+    "moment": "^2.29.4",
+    "parsleyjs": "^2.3.13"
   },
   "devDependencies": {
     "eslint": "^8.25.0",


### PR DESCRIPTION
Favicon:
everything was already there, just needed to add the line code that uploaded the image

Parsleyjs (copied from CROP):
added package in package.json and package-lock.json, plus moved the line to upload it in the javascript block.

Parsleyjs version is 2.3.13, which is quite old, but I would stick with this atm. Don't know what are the pros of a newer version.

Checks: 
- when you open the webpage you should see an icon at the top webpage bar (this is what we already had, if you don't like we can change it)
- in the login page, if you open the console, no more error regarding parsleyjs as it should be there and uploaded correctly