### PR TITLE
Remove dead code

### DIFF
--- a/dtbase/backend/run.sh
+++ b/dtbase/backend/run.sh
@@ -4,7 +4,6 @@ export LC_ALL=C.UTF-8
 export LANG=C.UTF-8
 
 export FLASK_APP=dtbase_app.py
-export FLASK_ENV=development
 
 if test -f "../../.secrets/dtenv.sh"; then
     source ../../.secrets/dtenv.sh

--- a/dtbase/backend/run_localdb.sh
+++ b/dtbase/backend/run_localdb.sh
@@ -4,7 +4,6 @@ export LC_ALL=C.UTF-8
 export LANG=C.UTF-8
 
 export FLASK_APP=dtbase_app.py
-export FLASK_ENV=development
 
 if test -f "../../.secrets/dtenv_localdb.sh"; then
     source ../../.secrets/dtenv_localdb.sh

--- a/dtbase/webapp/app/base/routes.py
+++ b/dtbase/webapp/app/base/routes.py
@@ -30,12 +30,6 @@ def route_template(template: str) -> str:
     return render_template(template + ".html")
 
 
-@blueprint.route("/fixed_<template>")
-@login_required
-def route_fixed_template(template: str) -> str:
-    return render_template("fixed/fixed_{}.html".format(template))
-
-
 @blueprint.route("/page_<error>")
 def route_errors(error: Any) -> str:
     return render_template("errors/page_{}.html".format(error))

--- a/dtbase/webapp/run.sh
+++ b/dtbase/webapp/run.sh
@@ -4,7 +4,6 @@ export LC_ALL=C.UTF-8
 export LANG=C.UTF-8
 
 export FLASK_APP=frontend_app.py
-export FLASK_ENV=development
 
 if [ -n "$1" ] && [ "$1" -gt "-1" ]
 then


### PR DESCRIPTION
This stuff wasn't doing anything. The `FLASK_ENV` thing _used to_ set flask to run in debug mode. The new equivalent would be `FLASK_DEBUG=true`, but I think that's a bad idea, because it's what's getting run in the production docker containers. Locally though, I personally like using `FLASK_DEBUG=true`, it makes it such that when you edit the code Flask automatically reloads with the latest changes.