### PR TITLE
Add Auto-login to frontend

### DIFF
--- a/DeveloperDocs.md
+++ b/DeveloperDocs.md
@@ -82,10 +82,7 @@ The DTBase frontend is currently an extremely lightweight Flask webapp:
 3. Navigate to the directory `dtbase/webapp` and run the command `./run.sh`.
 4. You should now be able to view the webapp on your browser at http://localhost:8000.
 5. You can log in with the username `default_user@localhost` and the password you set above when you created `dtenv_localdb.sh`.
-6. Like for the backend, you can use different modes for the frontend, by running e.g.
-   `DT_CONFIG_MODE=No-login ./run.sh` to run with user login disabled. The valid
-   options for `DT_CONFIG_MODE` for the frontend can be found in
-   `dtbase/webapp/config.py`.
+6. Like for the backend, you can use different modes for the frontend, by running e.g. `DT_CONFIG_MODE=Auto-login ./run.sh` to be always automatically logged in as the default user (handy for development). The valid options for `DT_CONFIG_MODE` for the frontend can be found in `dtbase/webapp/config.py`.
 
 
 ### Running with an Azure Deployed Database

--- a/DeveloperDocs.md
+++ b/DeveloperDocs.md
@@ -82,8 +82,11 @@ The DTBase frontend is currently an extremely lightweight Flask webapp:
 3. Navigate to the directory `dtbase/webapp` and run the command `./run.sh`.
 4. You should now be able to view the webapp on your browser at http://localhost:8000.
 5. You can log in with the username `default_user@localhost` and the password you set above when you created `dtenv_localdb.sh`.
-6. Like for the backend, you can use different modes for the frontend, by running e.g. `DT_CONFIG_MODE=Auto-login ./run.sh` to be always automatically logged in as the default user (handy for development). The valid options for `DT_CONFIG_MODE` for the frontend can be found in `dtbase/webapp/config.py`.
+6. Like for the backend, you can use different modes for the frontend, by running e.g. `DT_CONFIG_MODE=Auto-login ./run.sh` to be always automatically logged in as the default user. The valid options for `DT_CONFIG_MODE` for the frontend can be found in `dtbase/webapp/config.py`.
 
+A tip: When developing the frontend, it can be very handy to run it with `FLASK_DEBUG=true DT_CONFIG_MODE=Auto-login ./run.sh`.
+The first environment variable makes it such that Flask restarts every time you make a change to the code, and the second one makes Flask automatically log in as the default user.
+This way when you make code changes, you can see the effect immediately in your browser without having to restart and/or log in.
 
 ### Running with an Azure Deployed Database
 

--- a/dtbase/webapp/config.py
+++ b/dtbase/webapp/config.py
@@ -39,13 +39,13 @@ class DebugConfig(Config):
     DISABLE_REGISTER = True
 
 
-class NoLoginConfig(DebugConfig):
-    LOGIN_DISABLED = True
+class AutoLoginConfig(DebugConfig):
+    pass
 
 
 config_dict = {
     "Production": ProductionConfig,
     "Test": TestConfig,
     "Debug": DebugConfig,
-    "No-login": NoLoginConfig,
+    "Auto-login": AutoLoginConfig,
 }


### PR DESCRIPTION
This makes it such that if you run the frontend with `DT_CONFIG_MODE=Auto-login ./run.sh` you will always be automatically logged in as the default user (assuming one exists). Very handy for development.