### PR TITLE
Improve locations

### DIFF
--- a/dtbase/backend/README.md
+++ b/dtbase/backend/README.md
@@ -124,7 +124,9 @@ The following endpoints are implemented:
     }
     ```
     where "datatype" must be one of "string", "integer", "float", "boolean".
-    - returns the payload, with status code 201
+    - returns status code
+        - 201 on success
+        - 409 if a schema with this name exists already
 
 
 ### `/location/insert-location`
@@ -141,14 +143,10 @@ The schema name will be a concatenation of the identifier names.
     }
     ```
     (where the values should be in the same order as the identifiers) and "datatype" must be one of "string", "integer", "float", "boolean".
-    - returns status code 201, along with json:
-    ```
-    {
-      "schema_name": <concatenation_of_identifier_names>,
-      <identifier_name>: <value>,
-      ...
-    }
-    ```
+    - returns status code
+        - 201 on success
+        - 409 if the location exists already
+    - on success the return payload will also include a `schema_name` field.
 
 
 ### `/location/insert-location-for-schema`
@@ -162,7 +160,10 @@ The schema name will be a concatenation of the identifier names.
     }
     ```
     with an identifier name and value for every identifier in the schema.
-    - returns status code 201, along with the payload.
+    - returns status code
+        - 201 on success
+        - 400 if the location schema does not exist
+        - 409 if the location exists already
 
 
 ### `/location/list-locations`
@@ -181,7 +182,6 @@ The schema name will be a concatenation of the identifier names.
 
 ### `/location/list-location-schemas`
 * A GET request will list all schemas:
-
     - returns
     ```
     [{"id": <id:int>, "name": <name:str>, "description":<description:str>,}, ...]
@@ -189,7 +189,6 @@ The schema name will be a concatenation of the identifier names.
 
 ### `/location/list-location-identifiers`
 * A GET request will list all identifiers:
-
     - returns
     ```
     [
@@ -209,33 +208,23 @@ The schema name will be a concatenation of the identifier names.
     ```
     {"schema_name": <schema_name:str>}
     ```
-    - returns
-    ```
-      {
-	"status": "success",
-	"message": "Location schema <schema_name> has been deleted"
-      }
-     ```
+    - returns status code
+        - 200 on success
+        - 400 if schema does not exist
 
 ### `/location/delete-location`
 * A DELETE request will remove the location with the specified schema name and values specified in the payload:
-
     - payload:
     ```
     {
        "schema_name" : <schema_name:str>,
         <identifier_name:str>: <value:float|int|str|bool>,
-	...
+        ...
     }
     ```
-
-    - returns
-    ```
-      {
-	"status": "success",
-	"message": "Location deleted successfully"
-      }
-     ```
+    - returns status code
+        - 200 on success
+        - 400 if schema does not exist
 
 
 ## Sensors

--- a/dtbase/core/exc.py
+++ b/dtbase/core/exc.py
@@ -1,0 +1,10 @@
+class RowExistsError(Exception):
+    pass
+
+
+class RowMissingError(Exception):
+    pass
+
+
+class TooManyRowsError(Exception):
+    pass

--- a/dtbase/tests/test_api_locations.py
+++ b/dtbase/tests/test_api_locations.py
@@ -34,6 +34,24 @@ def test_insert_location_schema(auth_client: AuthenticatedClient) -> None:
 
 
 @pytest.mark.skipif(not DOCKER_RUNNING, reason="requires docker")
+def test_insert_location_schema_duplicate(auth_client: AuthenticatedClient) -> None:
+    with auth_client as client:
+        schema = {
+            "name": "building-floor-room",
+            "description": "Find something within a building",
+            "identifiers": [
+                {"name": "building", "units": None, "datatype": "string"},
+                {"name": "floor", "units": None, "datatype": "integer"},
+                {"name": "room", "units": None, "datatype": "string"},
+            ],
+        }
+        response = client.post("/location/insert-location-schema", json=schema)
+        assert response.status_code == 201
+        response = client.post("/location/insert-location-schema", json=schema)
+        assert response.status_code == 409
+
+
+@pytest.mark.skipif(not DOCKER_RUNNING, reason="requires docker")
 def test_insert_location_no_schema(auth_client: AuthenticatedClient) -> None:
     with auth_client as client:
         location = {
@@ -50,12 +68,30 @@ def test_insert_location_no_schema(auth_client: AuthenticatedClient) -> None:
 
 
 @pytest.mark.skipif(not DOCKER_RUNNING, reason="requires docker")
+def test_insert_location_no_schema_duplicate(auth_client: AuthenticatedClient) -> None:
+    with auth_client as client:
+        location = {
+            "identifiers": [
+                {"name": "x_distance", "units": "m", "datatype": "float"},
+                {"name": "y_distance", "units": "m", "datatype": "float"},
+                {"name": "z_distance", "units": "m", "datatype": "float"},
+            ],
+            "values": [5.0, 0.1, 4.4],
+        }
+
+        response = client.post("/location/insert-location", json=location)
+        assert response.status_code == 201
+        response = client.post("/location/insert-location", json=location)
+        assert response.status_code == 409
+
+
+@pytest.mark.skipif(not DOCKER_RUNNING, reason="requires docker")
 def test_insert_location_nonexisting_schema(auth_client: AuthenticatedClient) -> None:
     with auth_client as client:
         # use a non-existing schema name to insert a location
-        with pytest.raises(ValueError):
-            location = {"a": 123.4, "b": 432.1, "schema_name": "fakey"}
-            client.post("/location/insert-location-for-schema", json=location)
+        location = {"a": 123.4, "b": 432.1, "schema_name": "fakey"}
+        response = client.post("/location/insert-location-for-schema", json=location)
+        assert response.status_code == 400
 
 
 @pytest.mark.skipif(not DOCKER_RUNNING, reason="requires docker")
@@ -76,6 +112,29 @@ def test_insert_location_existing_schema(auth_client: AuthenticatedClient) -> No
         location = {"x": 123.4, "y": 432.1, "schema_name": "xy"}
         response = client.post("/location/insert-location-for-schema", json=location)
         assert response.status_code == 201
+
+
+@pytest.mark.skipif(not DOCKER_RUNNING, reason="requires docker")
+def test_insert_location_existing_schema_duplicate(
+    auth_client: AuthenticatedClient,
+) -> None:
+    with auth_client as client:
+        schema = {
+            "name": "xy",
+            "description": "x-y coordinates in mm",
+            "identifiers": [
+                {"name": "x", "units": "mm", "datatype": "float"},
+                {"name": "y", "units": "mm", "datatype": "float"},
+            ],
+        }
+        response = client.post("/location/insert-location-schema", json=schema)
+        assert response.status_code == 201
+
+        location = {"x": 123.4, "y": 432.1, "schema_name": "xy"}
+        response = client.post("/location/insert-location-for-schema", json=location)
+        assert response.status_code == 201
+        response = client.post("/location/insert-location-for-schema", json=location)
+        assert response.status_code == 409
 
 
 @pytest.mark.skipif(not DOCKER_RUNNING, reason="requires docker")

--- a/dtbase/tests/test_locations.py
+++ b/dtbase/tests/test_locations.py
@@ -6,6 +6,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from dtbase.core import locations
+from dtbase.core.exc import RowExistsError, RowMissingError
 
 # Some constants we will use in the tests repeatedly.
 LATITUDE1 = -2.0
@@ -116,7 +117,7 @@ def test_insert_location_schema_no_identifierr(session: Session) -> None:
     """Try to insert a location schema that uses identifiers that don't exist."""
     insert_schemas(session)
     error_msg = "No location identifier 'longitude_misspelled'"
-    with pytest.raises(ValueError, match=error_msg):
+    with pytest.raises(RowMissingError, match=error_msg):
         locations.insert_location_schema(
             name="latlong_misspelled",
             description="Latitude and longitude misspelled",
@@ -141,7 +142,7 @@ def test_insert_location_duplicate(session: Session) -> None:
         "Location with schema 'latlong' and coordinates "
         f"{{'latitude': {LATITUDE1}, 'longitude': {LONGITUDE1}}} already exists."
     )
-    with pytest.raises(ValueError, match=error_msg):
+    with pytest.raises(RowExistsError, match=error_msg):
         locations.insert_location(
             "latlong",
             latitude=LATITUDE1,
@@ -153,7 +154,7 @@ def test_insert_location_duplicate(session: Session) -> None:
 def test_insert_location_no_schema(session: Session) -> None:
     """Try to insert a location with a non-existing schema."""
     insert_schemas(session)
-    with pytest.raises(ValueError, match="No location schema 'heightitude'"):
+    with pytest.raises(RowMissingError, match="No location schema 'heightitude'"):
         locations.insert_location(
             "heightitude", latitude=12.0, longitude=0.0, session=session
         )
@@ -218,7 +219,7 @@ def test_delete_location_identifier(session: Session) -> None:
 
     # Doing the same deletion again should fail, since that row is gone.
     error_msg = "No location identifier 'latitude'"
-    with pytest.raises(ValueError, match=error_msg):
+    with pytest.raises(RowMissingError, match=error_msg):
         locations.delete_location_identifier("latitude", session=session)
 
 
@@ -243,7 +244,7 @@ def test_delete_location_schema(session: Session) -> None:
 
     # Doing the same deletion again should fail, since that row is gone.
     error_msg = "No location schema 'latlong'"
-    with pytest.raises(ValueError, match=error_msg):
+    with pytest.raises(RowMissingError, match=error_msg):
         locations.delete_location_schema("latlong", session=session)
 
 
@@ -272,7 +273,7 @@ def test_delete_location(session: Session) -> None:
         "Location not found: latlong, "
         f"{{'latitude': {LATITUDE2}, 'longitude': {LONGITUDE2}}}"
     )
-    with pytest.raises(ValueError, match=error_msg):
+    with pytest.raises(RowMissingError, match=error_msg):
         locations.delete_location_by_coordinates(
             "latlong",
             latitude=LATITUDE2,
@@ -291,7 +292,7 @@ def test_delete_location_nonexistent(session: Session) -> None:
     """Try to delete a non-existent location."""
     insert_locations(session)
     error_msg = "Location not found: latlong, {'latitude': 0.0, 'longitude': 0.0}"
-    with pytest.raises(ValueError, match=error_msg):
+    with pytest.raises(RowMissingError, match=error_msg):
         locations.delete_location_by_coordinates(
             "latlong", latitude=0.0, longitude=0.0, session=session
         )

--- a/dtbase/webapp/app/base/static/javascript/location.js
+++ b/dtbase/webapp/app/base/static/javascript/location.js
@@ -24,5 +24,9 @@ function updateForm() {
 }
 
 window.onload = function () {
-  document.getElementById("schema").addEventListener("change", updateForm);
+  const schema = document.getElementById("schema");
+  schema.addEventListener("change", updateForm);
+  if (schema.value != "") {
+    updateForm();
+  }
 };

--- a/dtbase/webapp/app/locations/routes.py
+++ b/dtbase/webapp/app/locations/routes.py
@@ -34,12 +34,6 @@ def submit_location_schema() -> Response:
     identifier_datatypes = request.form.getlist("identifier_datatype[]")
     identifier_existing = request.form.getlist("identifier_existing[]")
 
-    # print the values
-    print("Names: ", identifier_names)
-    print("Units: ", identifier_units)
-    print("Datatypes: ", identifier_datatypes)
-    print("Existing: ", identifier_existing)
-
     identifiers = [
         {
             "name": name,
@@ -61,33 +55,6 @@ def submit_location_schema() -> Response:
         "identifiers": identifiers,
     }
 
-    # check if the schema already exists
-    existing_schemas_response = current_user.backend_call(
-        "get", "/location/list-location-schemas"
-    )
-    existing_schemas = existing_schemas_response.json()
-    if any(schema["name"] == name for schema in existing_schemas):
-        flash(f"The schema '{name}' already exists.", "error")
-        return new_location_schema(form_data=form_data)
-
-    # check if any of the identifiers already exist
-    existing_identifiers_response = current_user.backend_call(
-        "get", "/location/list-location-identifiers"
-    )
-
-    existing_identifiers = existing_identifiers_response.json()
-
-    # new identifiers shouldn't have the same name as existing identifiers
-    for idf in identifiers:
-        if not idf["is_existing"]:
-            for idf_ex in existing_identifiers:
-                if idf["name"] == idf_ex["name"]:
-                    flash(
-                        f"An identifier with the name '{idf['name']}' already exists.",
-                        "error",
-                    )
-                    return new_location_schema(form_data=form_data)
-
     try:
         response = current_user.backend_call(
             "post", "/location/insert-location-schema", form_data
@@ -96,7 +63,9 @@ def submit_location_schema() -> Response:
         flash(f"Error communicating with the backend: {e}", "error")
         return redirect(url_for(".new_location_schema"))
 
-    if response.status_code != 201:
+    if response.status_code == 409:
+        flash(f"The schema '{name}' already exists.", "error")
+    elif response.status_code != 201:
         flash(
             f"An error occurred while adding the location schema: {response}", "error"
         )
@@ -108,14 +77,16 @@ def submit_location_schema() -> Response:
 
 @login_required
 @blueprint.route("/new-location", methods=["GET"])
-def new_location() -> Response:
+def new_location() -> str:
     try:
         response = current_user.backend_call("get", "/location/list-location-schemas")
     except ConnectionError:
         return redirect("/backend_not_found_error")
     schemas = response.json()
-    print(schemas)
-    return render_template("location_form.html", schemas=schemas)
+    selected_schema = request.args.get("schema_name")
+    return render_template(
+        "location_form.html", schemas=schemas, selected_schema=selected_schema
+    )
 
 
 @login_required
@@ -123,7 +94,8 @@ def new_location() -> Response:
 def submit_location() -> Response:
     # Retrieve the name of the schema
     schema_name = request.form.get("schema")
-    print(f"============={schema_name}================")
+    # Once all is said and done handling the POST request, we redirect the user here.
+    redirected_destination = redirect(url_for(".new_location", schema_name=schema_name))
     # Retrieve the identifiers and values based on the schema
     payload = {"schema_name": schema_name}
     response = current_user.backend_call("get", "/location/get-schema-details", payload)
@@ -133,7 +105,7 @@ def submit_location() -> Response:
         form_data = utils.convert_form_values(schema["identifiers"], request.form)
     except ValueError as e:
         flash(str(e), "error")
-        return redirect(url_for(".new_location"))
+        return redirected_destination
 
     try:
         # Send a POST request to the backend
@@ -144,16 +116,17 @@ def submit_location() -> Response:
         )
     except Exception as e:
         flash(f"Error communicating with the backend: {e}", "error")
-        return redirect(url_for(".new_location"))
+        return redirected_destination
 
-    if response.status_code != 201:
+    if response.status_code == 409:
+        flash("Location already exists", "error")
+    elif response.status_code != 201:
         flash(
             f"An error occurred while adding the location: {response.json()}", "error"
         )
-        return redirect(url_for(".new_location"))
-
-    flash("Location added successfully", "success")
-    return redirect(url_for(".new_location"))
+    else:
+        flash("Location added successfully", "success")
+    return redirected_destination
 
 
 @login_required

--- a/dtbase/webapp/app/locations/templates/location_form.html
+++ b/dtbase/webapp/app/locations/templates/location_form.html
@@ -11,7 +11,14 @@
             <select class="form-control custom-select custom-input" id="schema" name="schema" onchange="updateForm()" required>
                 <option value="">-- Select a schema --</option>
                 {% for schema in schemas %}
-                    <option value="{{ schema.name }}">{{ schema.name }}</option>
+                    <option
+                        {% if selected_schema and schema.name == selected_schema %}
+                        selected
+                        {% endif %}
+                        value="{{ schema.name }}"
+                    >
+                    {{ schema.name }}
+                    </option>
                 {% endfor %}
             </select>
         </div>


### PR DESCRIPTION
* Improve the backend API for locations. It now returns more helpful responses, that explicitly say e.g. if we are trying to insert a location or schema that already exists, rather than giving a general error.
* To support the above, improve error handling in `locations.py`
* On the front end
  * Simplify the handling of duplicates. Functionality on this remains mostly the same.
  * Make the new location page remember the schema you had selected after you click submit.