### PR TITLE
Sensors attached to model runs and more backend tests

### DIFF
--- a/dtbase/backend/README.md
+++ b/dtbase/backend/README.md
@@ -202,6 +202,33 @@ The schema name will be a concatenation of the identifier names.
     ]
     ```
 
+### `/location/get-schema-details`
+* A GET request to get all information, including identifiers, for a location schema:
+
+    - payload should be
+    ```
+    {
+      "schema_name": <schema_name:str>
+    }
+    ```
+    - returns 400 if schema name isn't valid, otherwise status code 200 with
+    ```
+    {
+      "id": <id:int>,
+      "name": <name:str>,
+      "description": <description:str>,
+      "identifiers": [
+        {
+	      "id": <id:int>,
+	      "name": <name:str>,
+	      "datatype": <datatype:str>,
+	      "units": <units:str>,
+        },
+        ...
+      ]
+    }
+    ```
+
 ### `/location/delete-location-schema`
 * A DELETE request will remove the schema with the specified name.
     - payload should contain:

--- a/dtbase/backend/README.md
+++ b/dtbase/backend/README.md
@@ -599,19 +599,25 @@ API endpoints for the models is as follows.
         "scenario": <scenario:str> (optional, by default all scenarios),
     }
     ```
-    datetime in dt_from and dt_to should be specified in the ISO 8601 format: '%Y-%m-%dT%H:%M:%S.
-
+    datetime in dt_from and dt_to should be specified in the ISO 8601 format:
+    '%Y-%m-%dT%H:%M:%S.
     - returns status code 200, alongside result in the form:
     ```
     [
         {
-            "id": <id:int>,
-            "model_id": <model_id:int>,
-            "model_name": <model_name:str>,
-            "scenario_description": <scenario_description:str>,
-            "scenario_id": <scenario_id:int>,
-            "time_created": <time_created:datetime_string>
-        },
+            "id": <database id of the model run:int>,
+            "model_id": <database id of the model:int>,
+            "model_name": <name of the model:str>,
+            "scenario_id": <database id of the scenario:int>,
+            "scenario_description": <description of the scenario:str>,
+            "time_created": <time when this run was created:str in ISO 8601>,
+            "sensor_unique_id": <unique identifier of the associated sensor:str or
+                null>,
+            "sensor_measure": {
+                "name": <name of the associated sensor measure:str or null>,
+                "units": <units of the associated sensor measure:str or null>
+            }
+        }
         ...
     ]
     ```
@@ -622,15 +628,17 @@ API endpoints for the models is as follows.
     - Payload should have the form
     ```
     {
-        run_id: <run_id:int> (id of the model run),
-
+        run_id: <id of the model run:int>
     }
     ```
     - returns status code 200, alongside result in the form:
     ```
     {
-       "sensor_unique_id": <sensor_unique_id:str>,
-       "measure_name": <measure_name:str>
+        "sensor_unique_id": <sensor unique id:str>,
+        "sensor_measure": {
+            "name": <sensor measure name:str>,
+            "units": <sensor measure units:str>
+        }
     }
     ```
 

--- a/dtbase/backend/README.md
+++ b/dtbase/backend/README.md
@@ -617,7 +617,8 @@ API endpoints for the models is as follows.
     ```
 
 ### `/model/get-model-run-sensor-measure`
-* A GET request, will get the corresponding sensor_id and measure for a given model run.
+* A GET request, will get the corresponding sensor id and sensor measure for a given
+  model run.
     - Payload should have the form
     ```
     {
@@ -625,7 +626,6 @@ API endpoints for the models is as follows.
 
     }
     ```
-
     - returns status code 200, alongside result in the form:
     ```
     {
@@ -635,23 +635,25 @@ API endpoints for the models is as follows.
     ```
 
 ### `/model/get-model-run`
-* A GET request, will get the output of a model run for a given model measure.
+* A GET request, will get the output of a model run.
     - Payload should have the form
     ```
     {
         run_id: <run_id:int> (id of the model run),
-        measure_name: <measure_name:str>,
     }
     ```
 
     - returns status code 200, alongside result in the form:
     ```
-    [
-        {
-            "timestamp": <timestamp:str>,
-            "value": <value:integer|float|string|boolean>
-        },
-        ...
-    ]
+    {
+        measure1_name: [
+            {
+                "timestamp": <timestamp:str>,
+                "value": <value:integer|float|string|boolean>
+            },
+            ...
+        ]
+    }
     ```
-    timestamp string is specified in ISO 8601 format: '%Y-%m-%dT%H:%M:%S.
+    The returned dictionary will have as many key-value pairs as there are measures in
+    the model run. Timestamp string is specified in ISO 8601 format: '%Y-%m-%dT%H:%M:%S.

--- a/dtbase/backend/api/location/routes.py
+++ b/dtbase/backend/api/location/routes.py
@@ -249,7 +249,7 @@ def get_schema_details() -> Tuple[Response, int]:
     schema_name = payload["schema_name"]
     try:
         result = locations.get_schema_details(schema_name, session=db.session)
-    except Exception:
+    except RowMissingError:
         return jsonify({"message": "No such schema"}), 400
     return jsonify(result), 200
 

--- a/dtbase/backend/api/location/routes.py
+++ b/dtbase/backend/api/location/routes.py
@@ -247,7 +247,10 @@ def get_schema_details() -> Tuple[Response, int]:
     """
     payload = request.get_json()
     schema_name = payload["schema_name"]
-    result = locations.get_schema_details(schema_name, session=db.session)
+    try:
+        result = locations.get_schema_details(schema_name, session=db.session)
+    except Exception:
+        return jsonify({"message": "No such schema"}), 400
     return jsonify(result), 200
 
 

--- a/dtbase/backend/api/model/routes.py
+++ b/dtbase/backend/api/model/routes.py
@@ -10,6 +10,7 @@ from flask_jwt_extended import jwt_required
 from dtbase.backend.api.model import blueprint
 from dtbase.backend.utils import check_keys
 from dtbase.core import models
+from dtbase.core.exc import RowMissingError
 from dtbase.core.structure import SQLA as db
 
 
@@ -212,21 +213,35 @@ def insert_model_run() -> Tuple[Response, int]:
 
     POST request should have json data (mimetype "application/json") containing
     {
-        "model_name": <name of the model that was run:str>
-        "scenario_description": <description of the scenario:str>
-        "measures_and_values": <results of the run:list of dicts with the below keys>
-            "measure_name": <name of the measure reported:str>
-            "values": <values that the model outputs:list>
-            "timestamps": <timestamps associated with the values:list>
+        "model_name": <name of the model that was run:str>,
+        "scenario_description": <description of the scenario:str>,
+        "measures_and_values": [
+            {
+                "measure_name": <name of the measure reported:str>,
+                "values": <values that the model outputs:list>,
+                "timestamps": <timestamps associated with the values:list>
+            }
+            ...
+        ]
     }
-    The values can be strings, integers, floats, or booleans, depending on the measure.
-    There should as many values as there are timestamps.
+    The measures_and_values, which holds the results of the model should have as many
+    entries as this model records measures. The values can be strings, integers, floats,
+    or booleans, depending on the measure. There should as many values as there are
+    timestamps.
+
     Optionally the following can also be included in the paylod
     {
-        "time_created": <time when this run was run, `now` by default:string>
+        "time_created": <time when this run was run, `now` by default:string>,
         "create_scenario": <create the scenario if it doesn't already exist, False by
-                            default:boolean>
+                            default:boolean>,
+        "sensor_unique_id": <id for the associated sensor:string>,
+        "sensor_measure": {
+            "name": <name of the associated sensor measure:string>,
+            "units": <name of the associated sensor measure:string>
+        }
     }
+
+    Returns status code 201 on success.
     """
 
     payload = request.get_json()
@@ -236,7 +251,7 @@ def insert_model_run() -> Tuple[Response, int]:
         return error_response
     models.insert_model_run(**payload, session=db.session)
     db.session.commit()
-    return jsonify(payload), 201
+    return jsonify({"message": "Model run successfully inserted"}), 201
 
 
 @blueprint.route("/list-model-runs", methods=["GET"])
@@ -247,18 +262,34 @@ def list_model_runs() -> Tuple[Response, int]:
 
     GET request should have json data (mimetype "application/json") containing
     {
-        "model_name": <Name of the model to get runs for>,
-        "dt_from": <Datetime string for earliest readings to get. Inclusive. In ISO 8601
-            format: '%Y-%m-%dT%H:%M:%S'>.  Optional, defaults to datetime.now minus one
-            week.
-        "dt_to": <Datetime string for last readings to get. Inclusive. In ISO 8601
-            format: '%Y-%m-%dT%H:%M:%S'>. Optional, defaults to datetime.now.
+        "model_name": <Name of the model to get runs for:string>,
+        "dt_from": <Datetime for earliest readings to get. Inclusive. Optional, defaults
+            to now minus one week.:string>
+        "dt_to": <Datetime for last readings to get. Inclusive. Optional, defaults to
+            now.:string>
         "scenario": <The string description of the scenario to include runs for.
-            Optional, by default all scenarios>,
+            Optional, by default all scenarios.:string>,
     }
+    Both dt_from and dt_to should be in ISO 8601 format: '%Y-%m-%dT%H:%M:%S'.
 
-    Returns:
-        A list of tuples (values, timestamp) that are the result the model run.
+    On success, returns 200 with
+    [
+        {
+            "id": <database id of the model run:int>,
+            "model_id": <database id of the model:int>,
+            "model_name": <name of the model:str>,
+            "scenario_id": <database id of the scenario:int>,
+            "scenario_description": <description of the scenario:str>,
+            "time_created": <time when this run was created:str in ISO 8601>,
+            "sensor_unique_id": <unique identifier of the associated sensor:str or
+                null>,
+            "sensor_measure": {
+                "name": <name of the associated sensor measure:str or null>,
+                "units": <units of the associated sensor measure:str or null>
+            }
+        }
+        ...
+    ]
     """
 
     payload = request.get_json()
@@ -292,6 +323,8 @@ def list_model_runs() -> Tuple[Response, int]:
     model_runs = models.list_model_runs(
         model_name, dt_from, dt_to, scenario, session=db.session
     )
+    for run in model_runs:
+        run["time_created"] = run["time_created"].isoformat()
     return jsonify(model_runs), 200
 
 
@@ -337,14 +370,24 @@ def get_model_run_sensor_measure() -> Tuple[Response, int]:
         run_id: <Database ID of the model run>,
     }
 
-    Returns:
-        Dict, with keys "sensor_unique_id", "measure_name"
+    Returns 200 with
+    {
+        "sensor_unique_id": <sensor unique id:str>,
+        "sensor_measure": {
+            "name": <sensor measure name:str>,
+            "units": <sensor measure units:str>
+        }
+    }
     """
     payload = request.get_json()
     required_keys = ["run_id"]
     error_response = check_keys(payload, required_keys, "/get-model-run-sensor-measure")
     if error_response:
         return error_response
-    result = models.get_model_run_sensor_measures(**payload)
-    result_dict = {"sensor_unique_id": result[0], "measure_name": result[1]}
-    return jsonify(result_dict), 200
+    try:
+        result = models.get_model_run_sensor_measure(**payload)
+        # The sensor_id is not needed in the API return value
+        del result["sensor_id"]
+    except RowMissingError:
+        return jsonify({"message": "No such model run"}), 400
+    return jsonify(result), 200

--- a/dtbase/backend/api/model/routes.py
+++ b/dtbase/backend/api/model/routes.py
@@ -102,6 +102,16 @@ def insert_model_scenario() -> Tuple[Response, int]:
 def list_model_scenarios() -> Tuple[Response, int]:
     """
     List all model scenarios in the database.
+
+    Returns JSON of the format
+    [
+        {
+            "id": <id:int>,
+            "model_id": <model_id:int>,
+            "description": <description:str|None|null>
+        },
+        ...
+    ]
     """
     result = models.list_model_scenarios(session=db.session)
     return jsonify(result), 200
@@ -111,9 +121,9 @@ def list_model_scenarios() -> Tuple[Response, int]:
 @jwt_required()
 def delete_model_scenario() -> Tuple[Response, int]:
     """
-    Delete a model scenario from the database
-    DELETE request should have json data (mimetype "application/json")
-    containing
+    Delete a model scenario from the database.
+
+    DELETE request should have json data (mimetype "application/json") containing
     {
         "model_name": <model_name:str>,
         "description": <description:str>

--- a/dtbase/core/locations.py
+++ b/dtbase/core/locations.py
@@ -448,7 +448,7 @@ def get_schema_details(
         .first()
     )
     if not schema:
-        raise Exception("No such schema")
+        raise RowMissingError("No such schema")
     schema_result = dict(schema._mapping)
 
     identifiers = (

--- a/dtbase/core/models.py
+++ b/dtbase/core/models.py
@@ -6,7 +6,8 @@ import sqlalchemy as sqla
 from sqlalchemy.orm import Session
 
 from dtbase.backend.utils import add_default_session
-from dtbase.core import utils
+from dtbase.core import sensors, utils
+from dtbase.core.exc import RowMissingError, TooManyRowsError
 from dtbase.core.structure import (
     Model,
     ModelMeasure,
@@ -16,6 +17,25 @@ from dtbase.core.structure import (
     Sensor,
     SensorMeasure,
 )
+
+
+def _collect_sensor_measure_results(row: dict) -> None:
+    """Collect data related to a sensor measure for a row.
+
+    If the input `row` has "sensor_measure_name" or "sensor_measure_units" that are not
+    `None`, collect them into an entry row["sensor_measure"] with keys "name" and
+    "units". Otherwise set row["sensor_measure"] to `None`. Remove the original entries.
+
+    Modifies the input in place, returns `None`.
+    """
+    row["sensor_measure"] = {
+        "name": row.get("sensor_measure_name", None),
+        "units": row.get("sensor_measure_units", None),
+    }
+    del row["sensor_measure_name"]
+    del row["sensor_measure_units"]
+    if set(row["sensor_measure"].values()) == {None}:
+        row["sensor_measure"] = None
 
 
 @add_default_session
@@ -39,7 +59,9 @@ def scenario_id_from_description(
     )
     result = session.execute(query).fetchall()
     if len(result) == 0:
-        raise ValueError(f"No model scenario '{description}' for model '{model_name}'.")
+        raise RowMissingError(
+            f"No model scenario '{description}' for model '{model_name}'."
+        )
     return result[0][0]
 
 
@@ -57,7 +79,7 @@ def measure_id_from_name(name: str, session: Optional[Session] = None) -> Any:
     query = sqla.select(ModelMeasure.id).where(ModelMeasure.name == name)
     result = session.execute(query).fetchall()
     if len(result) == 0:
-        raise ValueError(f"No model measure '{name}'.")
+        raise RowMissingError(f"No model measure '{name}'.")
     return result[0][0]
 
 
@@ -75,7 +97,7 @@ def measure_name_from_id(measure_id: int, session: Optional[Session] = None) -> 
     query = sqla.select(ModelMeasure.name).where(ModelMeasure.id == measure_id)
     result = session.execute(query).fetchall()
     if len(result) == 0:
-        raise ValueError(f"No model measure '{measure_id}'.")
+        raise RowMissingError(f"No model measure '{measure_id}'.")
     return result[0][0]
 
 
@@ -93,7 +115,7 @@ def model_id_from_name(name: str, session: Optional[Session] = None) -> Any:
     query = sqla.select(Model.id).where(Model.name == name)
     result = session.execute(query).fetchall()
     if len(result) == 0:
-        raise ValueError(f"No model named '{name}'")
+        raise RowMissingError(f"No model named '{name}'")
     return result[0][0]
 
 
@@ -211,10 +233,10 @@ def insert_model_product(
     measure_result = session.execute(measure_query).fetchall()
     if measure_result is None:
         msg = f"Unknown model measure '{measure_name}'"
-        raise ValueError(msg)
+        raise RowMissingError(msg)
     if len(measure_result) > 1:
         msg = f"Multiple model measures called '{measure_name}'"
-        raise ValueError(msg)
+        raise TooManyRowsError(msg)
     expected_datatype = measure_result[0][0]
 
     # Check that the data type is correct
@@ -255,8 +277,8 @@ def insert_model_run(
     model_name: str,
     scenario_description: str,
     measures_and_values: str,
-    sensor_id: Optional[int] = None,
-    sensor_measure_id: Optional[int] = None,
+    sensor_unique_id: Optional[str] = None,
+    sensor_measure: Optional[dict[str, str]] = None,
     time_created: dt.datetime = dt.datetime.now(dt.timezone.utc),
     create_scenario: bool = False,
     session: Optional[Session] = None,
@@ -273,9 +295,10 @@ def insert_model_run(
                 values: Values that the model outputs as an iterable.
                 timestamps: Timestamps associated with the values, an iterable of the
                     same length.
-        sensor_id:int (optional) - database ID of sensor against which results should be
-                     compared.
-        sensor_measure_id: int (optional) - measure (e.g. "temperature") to compare to.
+        sensor_unique_id:str (optional) - unique ID of the sensor against which results
+            should be compared.
+        sensor_measure: dict[str,str] (optional) - measure (e.g. "temperature") to
+            compare to. Dictionary with keys "name" and "units".
         time_created: Time when this run was run. Optional, `now` by default.
         create_scenario: Whether to create the scenario if it doesn't already exist.
             Optional, False by default.
@@ -290,13 +313,26 @@ def insert_model_run(
         scenario_id = scenario_id_from_description(
             model_name, scenario_description, session=session
         )
-    except ValueError:
+    except RowMissingError:
         if create_scenario:
             scenario_id = insert_model_scenario(
                 model_name, scenario_description, session=session
             ).id
         else:
             raise
+
+    sensor_id = (
+        sensors.sensor_id_from_unique_identifier(sensor_unique_id, session=session)
+        if sensor_unique_id is not None
+        else None
+    )
+    sensor_measure_id = (
+        sensors.measure_id_from_name_and_units(
+            sensor_measure["name"], sensor_measure["units"], session=session
+        )
+        if sensor_measure is not None
+        else None
+    )
 
     # Create the ModelRun
     model_id = model_id_from_name(model_name, session=session)
@@ -342,7 +378,7 @@ def list_model_runs(
     Returns:
         List of model runs, each being a dict with keys:
          "id","model_id", "model_name", "scenario_id", "scenario_description",
-         "time_created"
+         "time_created", "sensor_unique_id", "sensor_measure",
     """
     query = (
         sqla.select(
@@ -350,11 +386,16 @@ def list_model_runs(
             ModelRun.model_id,
             Model.name.label("model_name"),
             ModelRun.scenario_id,
+            Sensor.unique_identifier.label("sensor_unique_id"),
+            SensorMeasure.name.label("sensor_measure_name"),
+            SensorMeasure.units.label("sensor_measure_units"),
             ModelScenario.description.label("scenario_description"),
             ModelRun.time_created,
         )
         .join(Model, Model.id == ModelRun.model_id)
         .join(ModelScenario, ModelScenario.id == ModelRun.scenario_id)
+        .outerjoin(Sensor, Sensor.id == ModelRun.sensor_id)
+        .outerjoin(SensorMeasure, SensorMeasure.id == ModelRun.sensor_measure_id)
         .where(Model.name == model_name)
     )
     if dt_from is not None:
@@ -365,6 +406,8 @@ def list_model_runs(
         query = query.where(ModelScenario.description == scenario)
     result = session.execute(query).mappings().all()
     result = utils.row_mappings_to_dicts(result)
+    for row in result:
+        _collect_sensor_measure_results(row)
     return result
 
 
@@ -403,7 +446,7 @@ def get_model_run_results(run_id: int, session: Optional[Session] = None) -> Any
     """
     measures = get_model_run_measures(run_id, session=session)
     results = {}
-    for (measure_name, measure_id) in measures:
+    for measure_name, measure_id in measures:
         results[measure_name] = get_model_run_results_for_measure(
             run_id=run_id, measure_name=measure_name, session=session
         )
@@ -463,9 +506,7 @@ def get_model_run_measures(
 
 
 @add_default_session
-def get_model_run_sensor_measures(
-    run_id: int, session: Optional[Session] = None
-) -> Any:
+def get_model_run_sensor_measure(run_id: int, session: Optional[Session] = None) -> Any:
     """
     Get the info about what sensor/measure can be compared to a given ModelRun.
 
@@ -473,16 +514,25 @@ def get_model_run_sensor_measures(
         run_id:int Database ID of the model run
         session: SQLAlchemy session. Optional
     Returns:
-        tuple (<sensor_unique_id:str>, <measure_name:str>)
+        tuple (<sensor unique id:str>, <measure name:str>, <measure units:str>)
     """
     query = (
-        sqla.select(ModelRun.sensor_id, Sensor.unique_identifier, SensorMeasure.name)
-        .join(Sensor, Sensor.id == ModelRun.sensor_id)
-        .join(SensorMeasure, SensorMeasure.id == ModelRun.sensor_measure_id)
+        sqla.select(
+            ModelRun.sensor_id,
+            Sensor.unique_identifier.label("sensor_unique_id"),
+            SensorMeasure.name.label("sensor_measure_name"),
+            SensorMeasure.units.label("sensor_measure_units"),
+        )
+        .outerjoin(Sensor, Sensor.id == ModelRun.sensor_id)
+        .outerjoin(SensorMeasure, SensorMeasure.id == ModelRun.sensor_measure_id)
         .where((ModelRun.id == run_id))
     )
-    result = session.execute(query).fetchall()
-    return result[0][1:]
+    result = session.execute(query).mappings().all()
+    if len(result) == 0:
+        raise RowMissingError(f"No model run with id {run_id}")
+    result = utils.row_mappings_to_dicts(result)[0]
+    _collect_sensor_measure_results(result)
+    return result
 
 
 @add_default_session
@@ -500,7 +550,7 @@ def delete_model(model_name: str, session: Optional[Session] = None) -> None:
     """
     result = session.execute(sqla.delete(Model).where(Model.name == model_name))
     if result.rowcount == 0:
-        raise ValueError(f"No model named '{model_name}'.")
+        raise RowMissingError(f"No model named '{model_name}'.")
 
 
 @add_default_session
@@ -527,7 +577,9 @@ def delete_model_scenario(
         )
     )
     if result.rowcount == 0:
-        raise ValueError(f"No model scenario '{description}' for model '{model_name}'.")
+        raise RowMissingError(
+            f"No model scenario '{description}' for model '{model_name}'."
+        )
 
 
 @add_default_session
@@ -545,7 +597,7 @@ def delete_model_measure(name: str, session: Optional[Session] = None) -> None:
     """
     result = session.execute(sqla.delete(ModelMeasure).where(ModelMeasure.name == name))
     if result.rowcount == 0:
-        raise ValueError(f"No model measure named '{name}'.")
+        raise RowMissingError(f"No model measure named '{name}'.")
 
 
 @add_default_session
@@ -561,7 +613,7 @@ def delete_model_run(run_id: int, session: Optional[Session] = None) -> None:
     """
     result = session.execute(sqla.delete(ModelRun).where(ModelRun.id == run_id))
     if result.rowcount == 0:
-        raise ValueError(f"No model run with ID {run_id}")
+        raise RowMissingError(f"No model run with ID {run_id}")
 
 
 @add_default_session

--- a/dtbase/core/utils.py
+++ b/dtbase/core/utils.py
@@ -6,6 +6,7 @@ import io
 import json
 import logging
 import uuid
+from collections.abc import Sequence
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Tuple
 
@@ -35,7 +36,7 @@ from dtbase.core.structure import (
 
 def get_db_session(
     return_engine: bool = False,
-) -> (Tuple[Session, Engine] | Session | None):
+) -> Tuple[Session, Engine] | Session | None:
     """
     Get an SQLAlchemy session on the database.
 
@@ -103,7 +104,7 @@ def query_result_to_array(
 
 def query_result_to_dict(
     query_result: List[ResultProxy], date_iso: bool = True
-) -> (Dict | ResultProxy):
+) -> Dict | ResultProxy:
     """
     If we have a single query result, return output as a dict rather than a list
     Args:
@@ -297,7 +298,7 @@ def check_datatype(value: str, datatype_name: str) -> bool:
     raise ValueError(f"Unrecognised datatype: {datatype_name}")
 
 
-def row_mappings_to_dicts(rows: List[RowMapping]) -> List[Dict]:
+def row_mappings_to_dicts(rows: Sequence[RowMapping]) -> List[Dict]:
     """Convert the list of RowMappings that SQLAlchemy's mappings() returns into plain
     dicts.
     """

--- a/dtbase/tests/test_api_locations.py
+++ b/dtbase/tests/test_api_locations.py
@@ -51,6 +51,44 @@ def test_insert_location_schema_duplicate(auth_client: AuthenticatedClient) -> N
         assert response.status_code == 409
 
 
+def test_get_location_schema_details(auth_client: AuthenticatedClient) -> None:
+    with auth_client as client:
+        schema = {
+            "name": "building-floor-room",
+            "description": "Find something within a building",
+            "identifiers": [
+                {"name": "building", "units": None, "datatype": "string"},
+                {"name": "floor", "units": None, "datatype": "integer"},
+                {"name": "room", "units": None, "datatype": "string"},
+            ],
+        }
+        response = client.post("/location/insert-location-schema", json=schema)
+        assert response.status_code == 201
+        response = client.get(
+            "/location/get-schema-details", json={"schema_name": schema["name"]}
+        )
+        assert response.status_code == 200
+        body = response.get_json()
+        assert set(body.keys()) == {"name", "description", "id", "identifiers"}
+        assert set(body["identifiers"][0].keys()) == {
+            "name",
+            "units",
+            "id",
+            "datatype",
+        }
+
+
+@pytest.mark.skipif(not DOCKER_RUNNING, reason="requires docker")
+def test_get_nonexistent_location_schema_details(
+    auth_client: AuthenticatedClient,
+) -> None:
+    with auth_client as client:
+        response = client.get(
+            "/location/get-schema-details", json={"schema_name": "nope"}
+        )
+        assert response.status_code == 400
+
+
 @pytest.mark.skipif(not DOCKER_RUNNING, reason="requires docker")
 def test_insert_location_no_schema(auth_client: AuthenticatedClient) -> None:
     with auth_client as client:

--- a/dtbase/tests/test_api_models.py
+++ b/dtbase/tests/test_api_models.py
@@ -6,8 +6,11 @@ import datetime as dt
 import pytest
 from flask import Flask
 from flask.testing import FlaskClient
+from werkzeug.test import TestResponse
 
 from dtbase.tests.conftest import AuthenticatedClient, check_for_docker
+from dtbase.tests.test_api_sensors import UNIQ_ID1 as SENSOR_ID1
+from dtbase.tests.test_api_sensors import insert_weather_sensor, insert_weather_type
 from dtbase.tests.utils import assert_unauthorized
 
 DOCKER_RUNNING = check_for_docker()
@@ -78,8 +81,13 @@ RUN1 = {
 RUN2 = {
     "model_name": MODEL_NAME1,
     "scenario_description": SCENARIO2,
-    "measures_and_values": [PRODUCT2],
+    "measures_and_values": [PRODUCT1, PRODUCT2],
     "time_created": (NOW - dt.timedelta(days=7)).isoformat(),
+    "sensor_unique_id": SENSOR_ID1,
+    "sensor_measure": {
+        "name": "temperature",
+        "units": "Kelvin",
+    },
 }
 RUN3 = {
     "model_name": MODEL_NAME2,
@@ -94,13 +102,13 @@ def insert_model(client: FlaskClient, name: str) -> None:
     assert response.status_code == 201
 
 
-def insert_model_measures(client: FlaskClient) -> None:
+def insert_model_measures(client: FlaskClient) -> tuple[TestResponse, TestResponse]:
     response1 = client.post("/model/insert-model-measure", json=MEASURE1)
     response2 = client.post("/model/insert-model-measure", json=MEASURE2)
     return response1, response2
 
 
-def insert_model_scenarios(client: FlaskClient) -> None:
+def insert_model_scenarios(client: FlaskClient) -> list[TestResponse]:
     insert_model(client, MODEL_NAME1)
     insert_model(client, MODEL_NAME2)
     responses = [
@@ -117,9 +125,13 @@ def insert_model_scenarios(client: FlaskClient) -> None:
     return responses
 
 
-def insert_model_runs(client: FlaskClient) -> None:
+def insert_model_runs(
+    client: FlaskClient,
+) -> tuple[TestResponse, TestResponse, TestResponse]:
     insert_model_measures(client)
     insert_model_scenarios(client)
+    insert_weather_type(client)
+    insert_weather_sensor(client)
     response1 = client.post("/model/insert-model-run", json=RUN1)
     response2 = client.post("/model/insert-model-run", json=RUN2)
     response3 = client.post("/model/insert-model-run", json=RUN3)
@@ -209,6 +221,7 @@ def test_delete_model_scenario(auth_client: AuthenticatedClient) -> None:
 def test_insert_model_measures(auth_client: AuthenticatedClient) -> None:
     with auth_client as client:
         responses = insert_model_measures(client)
+        assert responses is not None
         for response in responses:
             assert response.status_code == 201
 
@@ -220,6 +233,7 @@ def test_list_model_measures(auth_client: AuthenticatedClient) -> None:
         response = client.get("/model/list-model-measures")
         assert response.status_code == 200
         response_data = response.json
+        assert response_data is not None
         assert len(response_data) == 2
         expected_keys = {"name", "units", "datatype", "id"}
         assert set(response_data[0].keys()) == expected_keys
@@ -241,6 +255,7 @@ def test_delete_model_measures(auth_client: AuthenticatedClient) -> None:
         assert response.status_code == 200
         response = client.get("/model/list-model-measures")
         response_data = response.json
+        assert response_data is not None
         assert len(response_data) == 1
 
 
@@ -248,6 +263,7 @@ def test_delete_model_measures(auth_client: AuthenticatedClient) -> None:
 def test_insert_model_runs(auth_client: AuthenticatedClient) -> None:
     with auth_client as client:
         responses = insert_model_runs(client)
+        assert responses is not None
         for response in responses:
             assert response.status_code == 201
 
@@ -255,26 +271,60 @@ def test_insert_model_runs(auth_client: AuthenticatedClient) -> None:
 @pytest.mark.skipif(not DOCKER_RUNNING, reason="requires docker")
 def test_list_model_runs(auth_client: AuthenticatedClient) -> None:
     with auth_client as client:
-        responses = insert_model_runs(client)
+        insert_model_runs(client)
 
-        runs = {
+        payload = {
             "model_name": MODEL_NAME1,
             "dt_from": NOW.isoformat(),
             "dt_to": (NOW + dt.timedelta(days=10)).isoformat(),
             "scenario": SCENARIO1,
         }
+        response = client.get("/model/list-model-runs", json=payload)
+        assert response.status_code == 200
+        body = response.json
+        assert body is not None
+        assert len(body) == 1
 
-        responses = client.get("/model/list-model-runs", json=runs)
+        expected_keys = {
+            "id",
+            "model_id",
+            "model_name",
+            "scenario_id",
+            "scenario_description",
+            "time_created",
+            "sensor_unique_id",
+            "sensor_measure",
+        }
+        run = body[0]
+        assert set(run.keys()) == expected_keys
+        for k in ("model_name", "scenario_description"):
+            assert run[k] == RUN1[k]
+        for k in ("sensor_measure", "sensor_unique_id"):
+            assert run[k] is None
 
-        assert responses.status_code == 200
-        assert isinstance(responses.json, list)
-        assert len(responses.json) == 1
+        payload = {
+            "model_name": MODEL_NAME1,
+            "dt_from": (NOW - dt.timedelta(days=10)).isoformat(),
+            "dt_to": (NOW + dt.timedelta(days=10)).isoformat(),
+        }
+        response = client.get("/model/list-model-runs", json=payload)
+        assert response.status_code == 200
+        body = response.json
+        assert body is not None
+        assert len(body) == 2
+        for run in body:
+            assert set(run.keys()) == expected_keys
+            expected_run = RUN1 if run["id"] == 1 else RUN2
+            for k in expected_keys:
+                if k in expected_run:
+                    expected_value = expected_run[k]
+                    assert run[k] == expected_value
 
 
 @pytest.mark.skipif(not DOCKER_RUNNING, reason="requires docker")
 def test_get_model_run(auth_client: AuthenticatedClient) -> None:
     with auth_client as client:
-        responses = insert_model_runs(client)
+        insert_model_runs(client)
 
         runs = {
             "model_name": MODEL_NAME1,
@@ -282,9 +332,9 @@ def test_get_model_run(auth_client: AuthenticatedClient) -> None:
             "dt_to": (NOW + dt.timedelta(days=10)).isoformat(),
             "scenario": SCENARIO1,
         }
-        responses = client.get("/model/list-model-runs", json=runs)
-        assert responses.json is not None
-        run_id = responses.json[0]["id"]
+        response = client.get("/model/list-model-runs", json=runs)
+        assert response.json is not None
+        run_id = response.json[0]["id"]
 
         response = client.get("/model/get-model-run", json={"run_id": run_id})
         assert response.status_code == 200
@@ -301,6 +351,43 @@ def test_get_model_run(auth_client: AuthenticatedClient) -> None:
             {"timestamp": t, "value": v}
             for t, v in zip(expected_product["timestamps"], expected_product["values"])
         ]
+
+
+@pytest.mark.skipif(not DOCKER_RUNNING, reason="requires docker")
+def test_get_model_run_sensor_measure(auth_client: AuthenticatedClient) -> None:
+    with auth_client as client:
+        insert_model_runs(client)
+
+        runs = {
+            "model_name": MODEL_NAME1,
+            "dt_from": (NOW - dt.timedelta(days=10)).isoformat(),
+            "dt_to": (NOW + dt.timedelta(days=10)).isoformat(),
+        }
+        response = client.get("/model/list-model-runs", json=runs)
+        assert response.json is not None
+        assert len(response.json) == 2
+
+        for run in response.json:
+            run_id = run["id"]
+            response = client.get(
+                "/model/get-model-run-sensor-measure", json={"run_id": run_id}
+            )
+            assert response.status_code == 200
+            body = response.json
+            assert body is not None
+            assert set(body.keys()) == {
+                "sensor_unique_id",
+                "sensor_measure",
+            }
+            if run["scenario_description"] == SCENARIO2:
+                assert body["sensor_unique_id"] == SENSOR_ID1
+                assert body["sensor_measure"] == {
+                    "name": "temperature",
+                    "units": "Kelvin",
+                }
+            else:
+                assert body["sensor_unique_id"] is None
+                assert body["sensor_measure"] is None
 
 
 @pytest.mark.skipif(not DOCKER_RUNNING, reason="requires docker")


### PR DESCRIPTION
Adds tests for all the backend API endpoints that were missing them, and finishes the work on the endpoints related to inserting and getting information about sensors and sensor measures associated with model runs. In the process, fix various small things in the files I was editing.

Builds on #165, so merging that first will make the diff for this shorter.

Closes #126 and #41