### PR TITLE
custom webapp name

### DIFF
--- a/infrastructure/__main__.py
+++ b/infrastructure/__main__.py
@@ -157,6 +157,7 @@ def create_backend_webapp(
             linux_fx_version=f"DOCKER|{BACKEND_DOCKER_URL}",
         ),
         https_only=True,
+        name=f"{RESOURCE_NAME_PREFIX}-{name}",
     )
     return webapp
 
@@ -197,6 +198,7 @@ def create_frontend_webapp(
             linux_fx_version=f"DOCKER|{FRONTEND_DOCKER_URL}",
         ),
         https_only=True,
+        name=f"{RESOURCE_NAME_PREFIX}-{name}",
     )
     return webapp
 


### PR DESCRIPTION
With this change we can create the webapps with custom names, without the random string attached at the end. 
For example we will have "nwtwin-frontend.azurewebsites.net" instead of "nwtwin-frontend123182948.azurewebsites.net".

Side comment: to change the domain we either need to own one or we need to buy it from Azure at the price of 12 $ per year.

This solves #200 