### PR TITLE
Continous deployment

### DIFF
--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -19,4 +19,4 @@
     complaining about the database failing, you can manually login to the PostgreSQL
     server you've created and create the database yourself. You will then have a
     functioning deployment of DTBase. Hopefully soon this workaround won't be necessary.
-14. Set up continuous deployment by selecting your WebApp in the Azure Portal, navigating to Deployment Center, enabling continuous deployment under Container Registry, adding the image name, and copying the generated Webhook URL; then, head to DockerHub, select the linked container, create a new webhook using the copied URL, and repeat for each WebApp.
+14. Set up continuous deployment by selecting your WebApp in the Azure Portal, navigating to Deployment Center, and copying the generated Webhook URL; then, head to DockerHub, select the linked container, create a new webhook using the copied URL, and repeat for each WebApp.


### PR DESCRIPTION
This PR adds an instruction to set the continuous deployment of WebApps (e.g. whenever a new version of a docker container is created, the webapp automatically pulls it). 
The instruction is very simple, which simply requires to copy a link from the Azure Portal and paste it to the respective docker container (same as creating a Github secret).
I checked if this could have been implemented directly with Pulumi, but all the resources I found are not clear enough and it looks like that there's need of at least one manual action, which makes this not worth it, in my opinion.
I am happy to spend more time to find another solution if you guys prefer.

Closes #201 .