### PR TITLE
Add setting default configuration in Arima

### DIFF
--- a/dtbase/models/arima.py
+++ b/dtbase/models/arima.py
@@ -58,6 +58,7 @@ class ArimaModel(BaseModel):
     def __init__(self, config: Optional[dict] = None) -> None:
         super().__init__()
         self.config = config
+        self.set_config_defaults()
 
     @staticmethod
     def _report_errors_for_data(data: pd.Series) -> None:


### PR DESCRIPTION
The `set_config_defaults` function wasn't being called anywhere.